### PR TITLE
Multi instance fix

### DIFF
--- a/coin-collection-manager-app/src/e2e/java/io/github/kevinmaggi/coin_collection_manager/app/AppE2E.java
+++ b/coin-collection-manager-app/src/e2e/java/io/github/kevinmaggi/coin_collection_manager/app/AppE2E.java
@@ -201,6 +201,8 @@ public class AppE2E extends AssertJSwingJUnitTestCase {
 				return window.label("albumSelection").text() == " ";
 			}
 		}, timeout(TIMEOUT));
+		
+		assertThat(window.label("albumSelection").text().trim()).isEmpty();
 	}
 	
 	@Test @GUITest
@@ -387,6 +389,8 @@ public class AppE2E extends AssertJSwingJUnitTestCase {
 				return window.label("coinSelection").text() == " ";
 			}
 		}, timeout(TIMEOUT));
+		
+		assertThat(window.label("coinSelection").text().trim()).isEmpty();
 	}
 	
 	@Test @GUITest

--- a/coin-collection-manager-business/src/it/java/io/github/kevinmaggi/coin_collection_manager/business/service/transactional/TransactionalServiceWithPostgresIT.java
+++ b/coin-collection-manager-business/src/it/java/io/github/kevinmaggi/coin_collection_manager/business/service/transactional/TransactionalServiceWithPostgresIT.java
@@ -270,6 +270,9 @@ class TransactionalServiceWithPostgresIT {
 			initCoins();
 			
 			ALBUM_COMM_1.setOccupiedSlots(ALBUM_COMM_1.getNumberOfSlots());
+			em.getTransaction().begin();
+			em.merge(ALBUM_COMM_1);
+			em.getTransaction().commit();
 			
 			assertThatThrownBy(() -> coinManager.addCoin(COIN_COMM_1))
 			.isInstanceOf(FullAlbumException.class);

--- a/coin-collection-manager-core/src/main/java/io/github/kevinmaggi/coin_collection_manager/core/repository/postgresql/PostgresAlbumRepository.java
+++ b/coin-collection-manager-core/src/main/java/io/github/kevinmaggi/coin_collection_manager/core/repository/postgresql/PostgresAlbumRepository.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import io.github.kevinmaggi.coin_collection_manager.core.model.Album;
 import io.github.kevinmaggi.coin_collection_manager.core.repository.AlbumRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.TypedQuery;
 
@@ -45,7 +46,14 @@ public class PostgresAlbumRepository extends PostgresRepository implements Album
 		if (id == null)
 			throw new IllegalArgumentException("ID can't be null");
 		else
-			return em.find(Album.class, id);
+			try {
+				Album retrieved = em.find(Album.class, id);
+				if (retrieved != null)
+					em.refresh(retrieved);
+				return retrieved;
+			} catch (EntityNotFoundException e) {
+				return null;
+			}
 	}
 
 	/**

--- a/coin-collection-manager-core/src/main/java/io/github/kevinmaggi/coin_collection_manager/core/repository/postgresql/PostgresCoinRepository.java
+++ b/coin-collection-manager-core/src/main/java/io/github/kevinmaggi/coin_collection_manager/core/repository/postgresql/PostgresCoinRepository.java
@@ -8,6 +8,7 @@ import io.github.kevinmaggi.coin_collection_manager.core.model.Coin;
 import io.github.kevinmaggi.coin_collection_manager.core.model.Grade;
 import io.github.kevinmaggi.coin_collection_manager.core.repository.CoinRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.TypedQuery;
 
@@ -47,7 +48,14 @@ public class PostgresCoinRepository extends PostgresRepository implements CoinRe
 		if (id == null)
 			throw new IllegalArgumentException("ID can't be null");
 		else
-			return em.find(Coin.class, id);
+			try {
+				Coin retrieved = em.find(Coin.class, id);
+				if (retrieved != null)
+					em.refresh(retrieved);
+				return retrieved;
+			} catch (EntityNotFoundException e) {
+				return null;
+			}
 	}
 
 	/**

--- a/coin-collection-manager-core/src/test/java/io/github/kevinmaggi/coin_collection_manager/core/repository/postgresql/PostgresAlbumRepositoryTestCase.java
+++ b/coin-collection-manager-core/src/test/java/io/github/kevinmaggi/coin_collection_manager/core/repository/postgresql/PostgresAlbumRepositoryTestCase.java
@@ -103,6 +103,37 @@ class PostgresAlbumRepositoryTestCase {
 			
 			assertThat(repo.findById(uuid)).isEqualTo(ALBUM_1);
 		}
+	
+		@Test
+		@DisplayName("Test that is returned the updated object in the case the object in DB is modified")
+		void testFindByIdReturnesUpdatedObjectWhenDBIsModified() {
+			populateDB();
+			UUID uuid = ALBUM_1.getId();
+			
+			EntityManager otherEm = emf.createEntityManager();
+			otherEm.getTransaction().begin();
+			Album otherAlbum = otherEm.find(Album.class, uuid);
+			otherAlbum.setName("new name");
+			otherEm.merge(otherAlbum);
+			otherEm.getTransaction().commit();
+			
+			assertThat(repo.findById(uuid).getName()).isEqualTo("new name");
+		}
+		
+		@Test
+		@DisplayName("Test that is returned null if the object is removed from DB")
+		void testFindByIdReturnesNullWhenIsRemovedFromDB() {
+			populateDB();
+			UUID uuid = ALBUM_1.getId();
+			
+			EntityManager otherEm = emf.createEntityManager();
+			otherEm.getTransaction().begin();
+			Album otherAlbum = otherEm.find(Album.class, uuid);
+			otherEm.remove(otherAlbum);
+			otherEm.getTransaction().commit();
+			
+			assertThat(repo.findById(uuid)).isNull();
+		}
 	}
 	
 	@Nested

--- a/coin-collection-manager-core/src/test/java/io/github/kevinmaggi/coin_collection_manager/core/repository/postgresql/PostgresCoinRepositoryTestCase.java
+++ b/coin-collection-manager-core/src/test/java/io/github/kevinmaggi/coin_collection_manager/core/repository/postgresql/PostgresCoinRepositoryTestCase.java
@@ -115,6 +115,37 @@ public class PostgresCoinRepositoryTestCase {
 			
 			assertThat(repo.findById(uuid)).isEqualTo(COIN_1);
 		}
+	
+		@Test
+		@DisplayName("Test that is returned the updated object in the case the object in DB is modified")
+		void testFindByIdReturnesUpdatedObjectWhenDBIsModified() {
+			populateDB();
+			UUID uuid = COIN_1.getId();
+			
+			EntityManager otherEm = emf.createEntityManager();
+			otherEm.getTransaction().begin();
+			Coin otherCoin = otherEm.find(Coin.class, uuid);
+			otherCoin.setDescription("new description");
+			otherEm.merge(otherCoin);
+			otherEm.getTransaction().commit();
+			
+			assertThat(repo.findById(uuid).getDescription()).isEqualTo("new description");
+		}
+		
+		@Test
+		@DisplayName("Test that is returned null if the object is removed from DB")
+		void testFindByIdReturnesNullWhenIsRemovedFromDB() {
+			populateDB();
+			UUID uuid = COIN_1.getId();
+			
+			EntityManager otherEm = emf.createEntityManager();
+			otherEm.getTransaction().begin();
+			Coin otherCoin = otherEm.find(Coin.class, uuid);
+			otherEm.remove(otherCoin);
+			otherEm.getTransaction().commit();
+			
+			assertThat(repo.findById(uuid)).isNull();
+		}
 	}
 	
 	@Nested

--- a/coin-collection-manager-ui/src/it/java/io/github/kevinmaggi/coin_collection_manager/ui/view/swing/SwingViewWithPresentersIT.java
+++ b/coin-collection-manager-ui/src/it/java/io/github/kevinmaggi/coin_collection_manager/ui/view/swing/SwingViewWithPresentersIT.java
@@ -292,6 +292,14 @@ public class SwingViewWithPresentersIT extends AssertJSwingJUnitTestCase {
 		});
 		window.list("albumList").selectItem(ALBUM_PRE.toString());
 		
+		pause(new Condition("Label react to selection") {
+			@Override
+			public boolean test() {
+				// Is necessary to wait the perform of getCoinsByAlbum in order to allow it to release transaction
+				return !window.label("coinActual").text().contains("All coins");
+			}
+		}, timeout(TIMEOUT));
+		
 		em.getTransaction().begin();
 		em.remove(ALBUM_PRE);
 		em.getTransaction().commit();
@@ -352,6 +360,13 @@ public class SwingViewWithPresentersIT extends AssertJSwingJUnitTestCase {
 		});
 		
 		window.list("albumList").selectItem(ALBUM_PRE.toString());
+		
+		pause(new Condition("Label react to selection") {
+			@Override
+			public boolean test() {
+				return !window.label("albumSelection").text().trim().isEmpty();
+			}
+		}, timeout(TIMEOUT));
 		
 		em.getTransaction().begin();
 		em.remove(ALBUM_PRE);
@@ -674,6 +689,13 @@ public class SwingViewWithPresentersIT extends AssertJSwingJUnitTestCase {
 		});
 		
 		window.list("coinList").item(COIN_COMM_1.toString()).select();
+		
+		pause(new Condition("Label react to selection") {
+			@Override
+			public boolean test() {
+				return !window.label("coinSelection").text().trim().isEmpty();
+			}
+		}, timeout(TIMEOUT));
 		
 		em.getTransaction().begin();
 		em.remove(COIN_COMM_1);

--- a/coin-collection-manager-ui/src/main/java/io/github/kevinmaggi/coin_collection_manager/ui/view/swing/SwingView.java
+++ b/coin-collection-manager-ui/src/main/java/io/github/kevinmaggi/coin_collection_manager/ui/view/swing/SwingView.java
@@ -173,8 +173,9 @@ public class SwingView extends JFrame implements View {
 				if(!e.getValueIsAdjusting()) {
 					if(albumList.getSelectedIndex() != -1) {
 						new Thread(() -> {
-							albumPresenter.getAlbum(albumList.getSelectedValue().getId());
-							coinPresenter.getCoinsByAlbum(albumList.getSelectedValue());
+							Album selected = albumList.getSelectedValue();
+							albumPresenter.getAlbum(selected.getId());
+							coinPresenter.getCoinsByAlbum(selected);
 						}).start();
 					} else {
 						albumSelectionLabel.setText(" ");


### PR DESCRIPTION
The two method selectById now return the object up-to-date with the database (even if modified or deleted by another EntityManager, i.e. another instance of the app)